### PR TITLE
Update versions of dependent-map and dependent-sum

### DIFF
--- a/fraxl.cabal
+++ b/fraxl.cabal
@@ -41,10 +41,10 @@ library
         free >=5.0.2 && <5.2,
         transformers >=0.4.2.0 && <0.6,
         mtl >=2.2.2 && <2.3,
-        dependent-sum ==0.4.*,
-        dependent-map >=0.2.4.0 && <0.3,
+        dependent-sum >=0.4.0.0 && <0.7,
+        dependent-map >=0.3.1.0 && <0.4,
         type-aligned >=0.9.6 && <0.10,
-        fastsum >=0.1.0.0 && <0.2
+        fastsum >=0.1.0.0 && <0.4
 
 executable examples
     main-is: Main.hs

--- a/stack.yaml
+++ b/stack.yaml
@@ -5,4 +5,7 @@ packages:
 extra-deps:
 - type-aligned-0.9.6
 - fastsum-0.1.0.0
+- dependent-sum-0.6.2.0
+- constraints-extras-0.3.0.2
+- dependent-map-0.3.1.0
 resolver: lts-12.0


### PR DESCRIPTION
This allows clients to use the convenient template haskell derive methods for the relevant classes.